### PR TITLE
Experimental Streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,17 @@ To use this tool you have to run the tts_node. It has the following parameters:
 - frame_id: Frame of for the tts.
 - mode: The tts model. You can check the available models with `tts --list_models`.
 - speaker_wav: The wav file to perform voice cloning.
+- speaker: Which speaker voice to use for multi-speaker models. Check with `tts --model_name <model> --list_language_idx`.
 - device: The device to run the model same as in torch.
 
+### Format
 ```shell
-$ ros2 run tts_ros tts_node --ros-args -p chunk:=4096 -p frame_id:="your-frame" -p model:="your-model" -p speaker_wav:="/path/to/wav/file" device:="cpu/cuda"
+$ ros2 run tts_ros tts_node --ros-args -p chunk:=4096 -p frame_id:="your-frame" -p model:="your-model" -p speaker_wav:="/path/to/wav/file" -p device:="cpu/cuda"
+```
+
+### Example
+```shell
+$ ros2 run tts_ros tts_node --ros-args -p chunk:=4096 -p frame_id:="base_link" -p model:="tts_models/multilingual/multi-dataset/xtts_v2" -p speaker:="Ana Florence" -p device:="cuda"
 ```
 
 ## Demos

--- a/tts_ros/tts_ros/tts_node.py
+++ b/tts_ros/tts_ros/tts_node.py
@@ -55,6 +55,7 @@ class AudioCapturerNode(Node):
 
             ("model", "tts_models/en/ljspeech/vits"),
             ("speaker_wav", ""),
+            ("speaker", ""),
             ("device", "cpu")
         ])
 
@@ -67,6 +68,8 @@ class AudioCapturerNode(Node):
             "model").get_parameter_value().string_value
         self.speaker_wav = self.get_parameter(
             "speaker_wav").get_parameter_value().string_value
+        self.speaker = self.get_parameter(
+            "speaker").get_parameter_value().string_value
         self.device = self.get_parameter(
             "device").get_parameter_value().string_value
 
@@ -78,6 +81,9 @@ class AudioCapturerNode(Node):
             )
         ):
             self.speaker_wav = None
+
+        if not self.speaker:
+            self.speaker = None
 
         self.tts = TtsModel(self.model).to(self.device)
 
@@ -132,6 +138,7 @@ class AudioCapturerNode(Node):
         self.tts.tts_to_file(
             text,
             speaker_wav=self.speaker_wav,
+            speaker=self.speaker,
             language=language,
             file_path=audio_file.name
         )

--- a/tts_ros/tts_ros/tts_node.py
+++ b/tts_ros/tts_ros/tts_node.py
@@ -30,6 +30,7 @@ import pyaudio
 import tempfile
 import threading
 from TTS.api import TTS as TtsModel
+import numpy as np
 
 import rclpy
 from rclpy.node import Node
@@ -56,7 +57,8 @@ class AudioCapturerNode(Node):
             ("model", "tts_models/en/ljspeech/vits"),
             ("speaker_wav", ""),
             ("speaker", ""),
-            ("device", "cpu")
+            ("device", "cpu"),
+            ("stream", False),
         ])
 
         self.chunk = self.get_parameter(
@@ -72,6 +74,8 @@ class AudioCapturerNode(Node):
             "speaker").get_parameter_value().string_value
         self.device = self.get_parameter(
             "device").get_parameter_value().string_value
+        self.stream = self.get_parameter(
+            "stream").get_parameter_value().bool_value
 
         if (
             not self.speaker_wav or
@@ -104,6 +108,15 @@ class AudioCapturerNode(Node):
             callback_group=ReentrantCallbackGroup()
         )
 
+        self.get_logger().info(f"Stream: {self.stream} {self.speaker_wav}")
+
+        if self.stream and self.speaker_wav:
+            self.get_logger().info(f"Streaming. Getting embeddings from {self.speaker_wav}")
+            self.gpt_cond_latent, self.speaker_embedding = self.tts.synthesizer.tts_model.get_conditioning_latents(audio_path=[self.speaker_wav])
+        else:
+            self.stream = False
+
+
         self.get_logger().info("TTS node started")
 
     def destroy_node(self) -> bool:
@@ -127,60 +140,132 @@ class AudioCapturerNode(Node):
 
         request: TTS.Goal = goal_handle.request
 
+        start_time = time.time()
+        
         text = request.text
         language = request.language
 
         if not self.tts.is_multi_lingual:
             language = None
 
-        # create audio file
-        audio_file = tempfile.NamedTemporaryFile(mode="w+")
-        self.tts.tts_to_file(
-            text,
-            speaker_wav=self.speaker_wav,
-            speaker=self.speaker,
-            language=language,
-            file_path=audio_file.name
-        )
+        if not self.stream:
+            # create audio file
+            audio_file = tempfile.NamedTemporaryFile(mode="w+")
+            self.tts.tts_to_file(
+                text,
+                speaker_wav=self.speaker_wav,
+                speaker=self.speaker,
+                language=language,
+                file_path=audio_file.name
+            )
 
-        # pub audio
-        audio_file.seek(0)
-        wf = wave.open(audio_file.name, "rb")
-        audio_file.close()
-        audio_format = pyaudio.get_format_from_width(wf.getsampwidth())
+            # pub audio
+            audio_file.seek(0)
+            wf = wave.open(audio_file.name, "rb")
+            audio_file.close()
+            audio_format = pyaudio.get_format_from_width(wf.getsampwidth())
 
-        frequency = wf.getframerate() / self.chunk
-        pub_rate = self.create_rate(frequency)
+            frequency = wf.getframerate() / self.chunk
+            pub_rate = self.create_rate(frequency)
 
-        # send audio data
-        data = wf.readframes(self.chunk)
-        while data:
-            if not goal_handle.is_active:
-                return TTS.Result()
-
-            if goal_handle.is_cancel_requested:
-                goal_handle.canceled()
-                return TTS.Result()
-
-            audio_data_msg = data_to_msg(data, audio_format)
-            if audio_data_msg is None:
-                self.get_logger().error(f"Format {audio_format} unknown")
-                self._goal_handle.abort()
-                return TTS.Result()
-
-            msg = AudioStamped()
-            msg.header.frame_id = self.frame_id
-            msg.header.stamp = self.get_clock().now().to_msg()
-            msg.audio.audio_data = audio_data_msg
-            msg.audio.info.format = audio_format
-            msg.audio.info.channels = wf.getnchannels()
-            msg.audio.info.chunk = self.chunk
-            msg.audio.info.rate = wf.getframerate()
-
-            self.player_pub.publish(msg)
-            pub_rate.sleep()
-
+            # send audio data
             data = wf.readframes(self.chunk)
+
+            while data:
+                pub_rate.sleep()
+
+                if not goal_handle.is_active:
+                    return TTS.Result()
+
+                if goal_handle.is_cancel_requested:
+                    goal_handle.canceled()
+                    return TTS.Result()
+
+                audio_data_msg = data_to_msg(data, audio_format)
+                if audio_data_msg is None:
+                    self.get_logger().error(f"Format {audio_format} unknown")
+                    self._goal_handle.abort()
+                    return TTS.Result()
+
+                msg = AudioStamped()
+                msg.header.frame_id = self.frame_id
+                msg.header.stamp = self.get_clock().now().to_msg()
+                msg.audio.audio_data = audio_data_msg
+                msg.audio.info.format = audio_format
+                msg.audio.info.channels = wf.getnchannels()
+                msg.audio.info.chunk = self.chunk
+                msg.audio.info.rate = wf.getframerate()
+
+                self.player_pub.publish(msg)
+
+                data = wf.readframes(self.chunk)
+
+        else:
+            # Stream chunks
+            # These values might be specific to the model?
+            audio_format = pyaudio.paInt16
+            # audio_format = pyaudio.paFloat32
+            rate = 24000
+            channels = 1
+            frequency = rate / self.chunk
+            pub_rate = self.create_rate(frequency)
+
+            self.get_logger().debug(f"Streaming chunks")
+
+            # TODO: TTS/tts/layers/xtts/stream_generator.py:138: UserWarning: You have modified the pretrained model configuration to control generation. This is a deprecated strategy to control generation and will be removed soon, in a future version. Please use a generation configuration file (see https://huggingface.co/docs/transformers/main_classes/text_generation)
+
+            chunks = self.tts.synthesizer.tts_model.inference_stream(
+                text,
+                speaker_wav=self.speaker_wav,
+                speaker=self.speaker,
+                language=language,
+                gpt_cond_latent=self.gpt_cond_latent, 
+                speaker_embedding=self.speaker_embedding,
+                stream_chunk_size=self.chunk,
+                temperature=0.65,
+                repetition_penalty=10.0,
+                speed=1.0,
+                enable_text_splitting=True,
+            )
+            
+            for i, data in enumerate(chunks):
+                self.get_logger().debug(f"Streaming chunk number {i}")
+
+                if not goal_handle.is_active:
+                    return TTS.Result()
+
+                if goal_handle.is_cancel_requested:
+                    goal_handle.canceled()
+                    return TTS.Result()
+                
+                data = data.clone().detach().cpu().numpy()
+                data = data[None, : int(data.shape[0])]
+                data = np.clip(data, -1, 1)
+                data = (data * 32767).astype(np.int16)
+
+                audio_data_msg = data_to_msg(data.tobytes(), audio_format)
+                if audio_data_msg is None:
+                    self.get_logger().error(f"Format {audio_format} unknown")
+                    self._goal_handle.abort()
+                    return TTS.Result()
+
+                msg = AudioStamped()
+                msg.header.frame_id = self.frame_id
+                msg.header.stamp = self.get_clock().now().to_msg()
+                msg.audio.audio_data = audio_data_msg
+                msg.audio.info.format = audio_format
+                msg.audio.info.channels = channels
+                msg.audio.info.chunk = self.chunk
+                msg.audio.info.rate = rate
+
+                self.player_pub.publish(msg)
+                end_time = time.time()
+                self.get_logger().debug(f"Text to speech chunk {i} {end_time - start_time} seconds")
+                pub_rate.sleep()
+
+        end_time = time.time()
+        self.get_logger().debug(f"Text to speech took {end_time - start_time} seconds")
+
 
         goal_handle.succeed()
         return TTS.Result()


### PR DESCRIPTION
This is an initial attempt at adding streaming support. It works really well for me so far. Instead of waiting to generate the entire wave file for a long text, it will send the first chunk much sooner while it processes the rest. There is a little more pause between sentences, but it sounds much more responsive. 

As a bonus, it doesn't use any temp files.

It definitely needs some cleanup, especially the warning about using the newer configs:

```
TTS/tts/layers/xtts/stream_generator.py:138: UserWarning:
You have modified the pretrained model configuration to control generation.
This is a deprecated strategy to control generation and will be removed soon, in a future version. 
Please use a generation configuration file 
(see https://huggingface.co/docs/transformers/main_classes/text_generation)
```

Example launch file:
```py
import os
from launch_ros.actions import Node
from launch import LaunchDescription
from launch.actions import SetEnvironmentVariable
from ament_index_python.packages import get_package_share_directory
from launch.substitutions import LaunchConfiguration


def generate_launch_description():

    stdout_linebuf_envvar = SetEnvironmentVariable("RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED", "1")
    coqui_agreed_envvar = SetEnvironmentVariable("COQUI_AGREED", "1")

    tts_node_cmd = Node(
        package="tts_ros",
        executable="tts_node",
        output="both",
        parameters=[{
            "device": "cuda",
            "model": "tts_models/multilingual/multi-dataset/xtts_v2",
            "chunk": 4096,
            "speaker_wav": os.path.join(get_package_share_directory("deepdrive_ai"), "audio", "scarjo.wav"),
            # "speaker": "Maja Ruoho",
            "stream": LaunchConfiguration("stream", default=True),

        }],
        remappings=[("audio", "/audio/out")],
    )

    ld = LaunchDescription()

    ld.add_action(stdout_linebuf_envvar)
    ld.add_action(coqui_agreed_envvar)

    ld.add_action(tts_node_cmd)

    return ld
```

# Example timing (RTX4090)

```sh
ros2 action send_goal /say audio_common_msgs/action/TTS "{'text': 'Incorporating depth cloud images into the room clustering algorithm can significantly enhance the separation of rooms based on location by providing three-dimensional spatial data. This additional layer of data allows for the identification of structural features such as doorways, hallways, and walls, which are critical in distinguishing between different rooms or spaces. Heres how you can leverage depth cloud images for this purpose:

1. Processing Depth Clouds
3D Reconstruction: Use depth cloud images to create a 3D reconstruction of the environment. This step converts the 2D depth data into a 3D point cloud, which represents the physical layout and structures within the space.
Segmentation: Apply segmentation algorithms to the 3D point cloud to identify distinct structures such as walls, floors, ceilings, and openings. Machine learning models, particularly those trained on 3D data like PointNet or convolutional neural networks (CNNs) adapted for 3D data, can be effective for this task.
2. Identifying Structural Features
Doorways and Hallways Detection: Specifically focus on detecting doorways and hallways, as they are key indicators of transitions between rooms. This can involve looking for gaps in walls (doorways) or elongated, narrow spaces (hallways). Techniques might include geometric analysis (e.g., identifying rectangular shapes for doors) or specialized object recognition models trained to identify these features in 3D space.
Wall Detection: Identify continuous walls to delineate room boundaries. Analyzing the 3D point cloud can help detect continuous surfaces that define the perimeter of rooms.
3. Clustering Enhancements with Structural Features
Spatial Clustering with Structural Constraints: Integrate the identified structural features into the spatial clustering process. This could mean adjusting the clustering algorithm to treat doorways as boundaries that separate clusters or as connections between spatially distinct clusters (rooms).
Refinement Based on 3D Structure: Use the 3D structural information to refine the initial clusters generated from camera poses and observations. For instance, if two clusters are separated by a recognized wall structure, reinforce them as distinct rooms; conversely, if a supposed boundary between clusters is not corroborated by wall or doorway detection, consider merging the clusters.
4. Room Connectivity and Graph Creation
Connectivity Graph: Create a graph where nodes represent the identified rooms, and edges represent the connections between rooms through doorways or hallways. This graph can be dynamically updated as more data is processed, enhancing the representation of the environments layout.
5. Leveraging Machine Learning and Heuristics
Machine Learning Models: Utilize or train machine learning models to recognize specific architectural features that indicate room boundaries or connections. Supervised learning approaches can be effective if labeled training data is available.
Heuristics: Develop heuristics based on spatial and structural cues. For example, a heuristic might define that a doorway typically indicates a transition between rooms, or that a space surrounded by walls on all sides constitutes a separate room.
6. Continuous Refinement and Learning
As more depth data is collected and processed, continuously refine the model of the environment. Machine learning models can improve with more data, leading to better identification of structural features and more accurate room clustering.
By integrating depth cloud images and focusing on the identification of key structural features like doorways and hallways, the room clustering algorithm can more effectively separate rooms based on their physical locations and the layout of the environment. This approach not only enhances the precision of spatial clustering but also provides a richer, more nuanced representation of indoor spaces.


'}"



```


```log
[tts_node-1] [INFO] [1715294182.427548287] [tts_node]: Streaming chunks
[tts_node-1] [INFO] [1715294182.428974460] [tts_node]: Got chunks
[tts_node-1] [INFO] [1715294186.487602710] [tts_node]: Streaming chunk number 0
[tts_node-1] [INFO] [1715294186.529444736] [tts_node]: Text to speech chunk 0 4.105112791061401 seconds
[tts_node-1] [INFO] [1715294190.727683921] [tts_node]: Streaming chunk number 1
[tts_node-1] [INFO] [1715294190.773543510] [tts_node]: Text to speech chunk 1 8.349586009979248 seconds
[tts_node-1] [INFO] [1715294195.248719560] [tts_node]: Streaming chunk number 2
[tts_node-1] [INFO] [1715294195.295782547] [tts_node]: Text to speech chunk 2 12.871795892715454 seconds
[tts_node-1] [INFO] [1715294198.383323720] [tts_node]: Streaming chunk number 3
[tts_node-1] [INFO] [1715294198.415354464] [tts_node]: Text to speech chunk 3 15.990603685379028 seconds
[tts_node-1] [INFO] [1715294202.323241021] [tts_node]: Streaming chunk number 4
[tts_node-1] [INFO] [1715294202.364454481] [tts_node]: Text to speech chunk 4 19.940497398376465 seconds
[tts_node-1] [INFO] [1715294206.880799737] [tts_node]: Streaming chunk number 5
[tts_node-1] [INFO] [1715294206.927408796] [tts_node]: Text to speech chunk 5 24.503442525863647 seconds
[tts_node-1] [INFO] [1715294211.313983173] [tts_node]: Streaming chunk number 6
[tts_node-1] [INFO] [1715294211.374658864] [tts_node]: Text to speech chunk 6 28.950695991516113 seconds
[tts_node-1] [INFO] [1715294214.377206309] [tts_node]: Streaming chunk number 7
[tts_node-1] [INFO] [1715294214.413941880] [tts_node]: Text to speech chunk 7 31.989957809448242 seconds
[tts_node-1] [INFO] [1715294218.860427735] [tts_node]: Streaming chunk number 8
[tts_node-1] [INFO] [1715294218.908248696] [tts_node]: Text to speech chunk 8 36.483691692352295 seconds
[tts_node-1] [INFO] [1715294223.794547132] [tts_node]: Streaming chunk number 9
[tts_node-1] [INFO] [1715294223.845610223] [tts_node]: Text to speech chunk 9 41.420939207077026 seconds
[tts_node-1] [INFO] [1715294227.987335668] [tts_node]: Streaming chunk number 10
[tts_node-1] [INFO] [1715294228.030912181] [tts_node]: Text to speech chunk 10 45.606929063797 seconds
[tts_node-1] [INFO] [1715294231.182646217] [tts_node]: Streaming chunk number 11
[tts_node-1] [INFO] [1715294231.214767998] [tts_node]: Text to speech chunk 11 48.79078197479248 seconds
[tts_node-1] [INFO] [1715294234.971290452] [tts_node]: Streaming chunk number 12
[tts_node-1] [INFO] [1715294235.011308800] [tts_node]: Text to speech chunk 12 52.58735108375549 seconds
[tts_node-1] [INFO] [1715294241.534881562] [tts_node]: Streaming chunk number 13
[tts_node-1] [INFO] [1715294241.604639320] [tts_node]: Text to speech chunk 13 59.180171966552734 seconds
[tts_node-1] [INFO] [1715294246.665977265] [tts_node]: Streaming chunk number 14
[tts_node-1] [INFO] [1715294246.720194328] [tts_node]: Text to speech chunk 14 64.29576349258423 seconds
[tts_node-1] [INFO] [1715294253.980184263] [tts_node]: Streaming chunk number 15
[tts_node-1] [INFO] [1715294254.057320759] [tts_node]: Text to speech chunk 15 71.63306403160095 seconds
[tts_node-1] [INFO] [1715294259.819512963] [tts_node]: Streaming chunk number 16
[tts_node-1] [INFO] [1715294259.881104707] [tts_node]: Text to speech chunk 16 77.45673513412476 seconds
[tts_node-1] [INFO] [1715294263.895584890] [tts_node]: Streaming chunk number 17
[tts_node-1] [INFO] [1715294263.938242208] [tts_node]: Text to speech chunk 17 81.51427912712097 seconds
[tts_node-1] [INFO] [1715294268.185988486] [tts_node]: Streaming chunk number 18
[tts_node-1] [INFO] [1715294268.231681031] [tts_node]: Text to speech chunk 18 85.8072030544281 seconds
[tts_node-1] [INFO] [1715294271.712224084] [tts_node]: Streaming chunk number 19
[tts_node-1] [INFO] [1715294271.747946032] [tts_node]: Text to speech chunk 19 89.32395839691162 seconds
[tts_node-1] [INFO] [1715294275.083933484] [tts_node]: Streaming chunk number 20
[tts_node-1] [INFO] [1715294275.119416157] [tts_node]: Text to speech chunk 20 92.69542503356934 seconds
[tts_node-1] [INFO] [1715294281.680530830] [tts_node]: Streaming chunk number 21
[tts_node-1] [INFO] [1715294281.750919397] [tts_node]: Text to speech chunk 21 99.32695746421814 seconds
[tts_node-1] [INFO] [1715294286.390150280] [tts_node]: Streaming chunk number 22
[tts_node-1] [INFO] [1715294286.437661052] [tts_node]: Text to speech chunk 22 104.01367282867432 seconds
[tts_node-1] [INFO] [1715294286.438412450] [tts_node]: Text to speech took 104.01444363594055 seconds
```